### PR TITLE
Fix wiiCam sensititivity settings for DIY camera.

### DIFF
--- a/Sensor/src/wiiCam/wiiCam.h
+++ b/Sensor/src/wiiCam/wiiCam.h
@@ -5,6 +5,7 @@
 #include "../IrPoint/IrPoint.h"
 
 //Registers
+#define SENSITIVITY_BLOCK1  0x00
 #define MAX_BRIGHTNESS_THR  0x06
 #define BRIGHTNESS_1        0x08
 #define MAX_OBJECTS         0x10


### PR DESCRIPTION
Fix wiiCam sensititivity settings for DIY camera.  The code this replaces did not work - it would never detect an IR source, and at least one other person on discord reported the same thing.  This code follows more documented behavior (what there is of it) and gives finer control than the few preset values that existed before.

Not sure why more folks are not seeing this - maybe not many DIY installs out there, or they have not updated to version 3.x of the firmware, or there is some minor difference in how some of the sen0158 cameras behave.
